### PR TITLE
Optimise performance of `getlambdaStep` function

### DIFF
--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -113,9 +113,9 @@ def getlambdaStep(params, Age, bact_load, IndD, bet, demog):
     np.sum(bact_load[o_children]) / len(o_children), np.sum(bact_load[adults]) / len(adults)])
     prevLambda = bet * (params['v_1'] * totalLoad + params['v_2'] * (totalLoad ** (params['phi'] + 1)))
 
-    a = len(y_children)
-    b = len(o_children)
-    c = len(adults)
+    a = len(y_children)/params['N']
+    b = len(o_children)/params['N']
+    c = len(adults)/params['N']
     epsm = 1 - params['epsilon']
     A = [
         prevLambda[0]*a + prevLambda[1]*epsm*b + prevLambda[2]*epsm*c,

--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -117,10 +117,13 @@ def getlambdaStep(params, Age, bact_load, IndD, bet, demog):
 
     # scales mixing with other groups
     social_mixing = (params['epsilon'] * np.diag(np.ones(3)) + (1 - params['epsilon'])) * demog_matrix
-    positions = list(map(assign_age_group, Age))
 
-    # removed 'scaling parameter'
-    return np.dot(social_mixing, prevLambda)[positions]
+    A = np.dot(social_mixing, prevLambda)
+    returned = np.ones(params['N'])
+    returned[y_children] = A[0]
+    returned[o_children] = A[1]
+    returned[adults] = A[2]
+    return returned
 
 def Reset(Age, demog, params):
 

--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -111,14 +111,17 @@ def getlambdaStep(params, Age, bact_load, IndD, bet, demog):
 
     totalLoad = np.array([np.sum(bact_load[y_children]) / len(y_children),
     np.sum(bact_load[o_children]) / len(o_children), np.sum(bact_load[adults]) / len(adults)])
-
     prevLambda = bet * (params['v_1'] * totalLoad + params['v_2'] * (totalLoad ** (params['phi'] + 1)))
-    demog_matrix = np.array([len(y_children), len(o_children), len(adults)] * 3).reshape(3, 3) / params['N']
 
-    # scales mixing with other groups
-    social_mixing = (params['epsilon'] * np.diag(np.ones(3)) + (1 - params['epsilon'])) * demog_matrix
-
-    A = np.dot(social_mixing, prevLambda)
+    a = len(y_children)
+    b = len(o_children)
+    c = len(adults)
+    epsm = 1 - params['epsilon']
+    A = [
+        prevLambda[0]*a + prevLambda[1]*epsm*b + prevLambda[2]*epsm*c,
+        prevLambda[0]*a*epsm + prevLambda[1]*b + prevLambda[2]*epsm*c,
+        prevLambda[0]*a*epsm + prevLambda[1]*epsm*b + prevLambda[2]*c,
+    ]
     returned = np.ones(params['N'])
     returned[y_children] = A[0]
     returned[o_children] = A[1]

--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -96,13 +96,6 @@ def get_MDA_times(MDA_dates, Start_date, burnin):
         MDA_times.append(burnin + int((MDA_dates[i] - Start_date).days/7))
     return np.array(MDA_times)
 
-def assign_age_group(age):
-    if age >= 15*52:
-        return 2
-    if age >= 9*52:
-        return 1
-    return 0
-
 def getlambdaStep(params, Age, bact_load, IndD, bet, demog):
 
     y_children = np.where(np.logical_and(Age >= 0, Age < 9 * 52))[0]  # Young children


### PR DESCRIPTION
This function computes the dot product of the social mixing matrix (3x3 matrix) and the `prevLambda` vector (of size 3).
Numpy indexing is finally use to assign each individual the right component of the resulting vector: if age <= 9, first component, if `9 < age <= 15`, second component and third component if `age > 15`.
```python
return np.dot(social_mixing, prevLambda)[positions]
```

### We don't have to (re)compute `positions`
However the intermediate step of computing the `positions` array can be bypassed by directly assigning components to the returned array:
```python
V = np.dot(social_mixing, prevLambda) # A vector with 3 components
returned = np.ones(params['N'])
returned[y_children] = V[0]
returned[o_children] = V[1]
returned[adults] = V[2]
return returned
```

### Avoiding numpy for small arrays

With only 3 age groups, using numpy for matrix and vector arithmetic isn't worth it. The function actually runs much faster by implementing the calculations "manually"
```python
    a = len(y_children)
    b = len(o_children)
    c = len(adults)
    epsm = 1 - params['epsilon']
    # V used to be np.dot(social_matrix, prevLambda)
    V = [
        prevLambda[0]*a + prevLambda[1]*epsm*b + prevLambda[2]*epsm*c,
        prevLambda[0]*a*epsm + prevLambda[1]*b + prevLambda[2]*epsm*c,
        prevLambda[0]*a*epsm + prevLambda[1]*epsm*b + prevLambda[2]*c,
    ]
```

I will need help (@mattg3004, @AnnaMB123 ?) to find more explicit names for vector `V`, `returned` and `prevLambda` :)