### PR TITLE
Use histogram to bin number of high infection counts per age group

### DIFF
--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -344,7 +344,8 @@ def sim_Ind_MDA(params, Tx_mat, vals, timesim, demog, bet, MDA_times, seed, stat
 
     prevalence = []
     infections = []
-    yearly_threshold_infs = np.zeros(( timesim+1, int(demog['max_age']/52)))
+    max_age = demog['max_age'] // 52 # max_age in weeks
+    yearly_threshold_infs = np.zeros((timesim+1, max_age))
     for i in range(1, 1 + timesim):
 
         if i in MDA_times:
@@ -357,19 +358,17 @@ def sim_Ind_MDA(params, Tx_mat, vals, timesim, demog, bet, MDA_times, seed, stat
 
         vals = stepF_fixed(vals=vals, params=params, demog=demog, bet=bet)
 
-        a = []
         children_ages_1_9 = np.logical_and(vals['Age'] < 10 * 52, vals['Age'] >= 52)
         n_children_ages_1_9 = children_ages_1_9.sum()
         n_true_diseased_children_1_9 = vals['IndD'][children_ages_1_9].sum()
         n_true_infected_children_1_9 = vals['IndI'][children_ages_1_9].sum()
         prevalence.append(n_true_diseased_children_1_9 / n_children_ages_1_9)
         infections.append(n_true_infected_children_1_9 / n_children_ages_1_9)
-        for l in range(0, int(demog['max_age']/52)):
-            index = np.logical_and(vals['Age'] >= (l*52), vals['Age'] < ((l+1)*52))
-            p = sum(vals['No_Inf'][index] > params['n_inf_sev'])/len(index)
-            a.append(p)
 
-        yearly_threshold_infs[i, :] = a
+        large_infection_count = (vals['No_Inf'] > params['n_inf_sev'])
+        # Cast weights to integer to be able to count
+        a, _ = np.histogram(vals['Age'], bins=max_age, weights=large_infection_count.astype(int))
+        yearly_threshold_infs[i, :] = a / params['N']
 
     vals['Yearly_threshold_infs'] = yearly_threshold_infs
     vals['True_Prev_Disease_children_1_9'] = prevalence # save the prevalence in children aged 1-9

--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -359,9 +359,9 @@ def sim_Ind_MDA(params, Tx_mat, vals, timesim, demog, bet, MDA_times, seed, stat
         vals = stepF_fixed(vals=vals, params=params, demog=demog, bet=bet)
 
         children_ages_1_9 = np.logical_and(vals['Age'] < 10 * 52, vals['Age'] >= 52)
-        n_children_ages_1_9 = children_ages_1_9.sum()
-        n_true_diseased_children_1_9 = vals['IndD'][children_ages_1_9].sum()
-        n_true_infected_children_1_9 = vals['IndI'][children_ages_1_9].sum()
+        n_children_ages_1_9 = np.count_nonzero(children_ages_1_9)
+        n_true_diseased_children_1_9 = np.count_nonzero(vals['IndD'][children_ages_1_9])
+        n_true_infected_children_1_9 = np.count_nonzero(vals['IndI'][children_ages_1_9])
         prevalence.append(n_true_diseased_children_1_9 / n_children_ages_1_9)
         infections.append(n_true_infected_children_1_9 / n_children_ages_1_9)
 


### PR DESCRIPTION
Currently function `sim_ind_MDA` spends about 40% of its time counting the ratio of individual who have bin infected more than `n_inf_sev` times, for each age.

```python
a = []
for l in range(0, int(demog['max_age']/52)):
    index = np.logical_and(vals['Age'] >= (l*52), vals['Age'] < ((l+1)*52))
    p = sum(vals['No_Inf'][index] > params['n_inf_sev'])/len(index)
    a.append(p)
```
this is repeated for each timestep.

The above is essentially computing a histogram: there is one bin per year (spanning 52 weeks) and histogram count is how many individual in bin have a number of infection above `params['n_inf_sev']`. The same thing can be computed using numpy.histogram:
```python
large_infection_count = (vals['No_Inf'] > params['n_inf_sev']) # boolean array
a, _ = np.histogram(vals['Age'], bins=max_age, weights=large_infection_count.astype(int))
```
where `max_age` is 60 and the boolean array is cast as integer to be able to count number of `True` values (otherwise `True + True = True`!)

This relatively simple change makes a big difference in performance (operation is ~10x faster).
