### PR TITLE
Add `num_cores` keyword argument to specify max number of concurrent jobs

### DIFF
--- a/trachoma/trachoma_simulations.py
+++ b/trachoma/trachoma_simulations.py
@@ -215,7 +215,8 @@ def Trachoma_Simulation(
     BetFilePath, MDAFilePath, PrevFilePath, InfectFilePath,
     SaveOutput=False, OutSimFilePath=None, InSimFilePath=None,
     rho=0.3, MDA_Cov=0.8, numReps=0,
-    useCloudStorage=False, download_blob_to_file=None, logger=None
+    useCloudStorage=False, download_blob_to_file=None, logger=None,
+    num_cores=-1,
 ):
 
     '''
@@ -340,7 +341,6 @@ def Trachoma_Simulation(
 
         # run simulations
         model_version = 'v20210329a'
-        num_cores = multiprocessing.cpu_count()
         print_function( f"Starting {numReps}x Trachoma runs on {num_cores} core(s), {model_version}" )
 
         start_time = time.time()


### PR DESCRIPTION
The default of `-1` is equivalent to `num_cores = multiprocessing.cpu_count()`, i.e. using all available cores.