### PR TITLE
Add sphinx documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: "Sphinx: Render and deploy docs"
+
+on:
+  push:
+    paths:
+      - 'docs/source/*'
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - run: pip install sphinx
+    - name: Install package
+      run: pip install .
+    - name: Run sphinx-build
+      run: make -C docs html
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-docs
+        path: docs/build/html/
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html

--- a/README.md
+++ b/README.md
@@ -82,4 +82,14 @@ cd tests
 python -m unittest test_endtoend.py
 ```
 
+### Building the docs
 
+You'll need to have [the sphinx static site generator](https://www.sphinx-doc.org) installed.  A good way to install Sphinx is to use [`pipx`](pipx.pypa.io).
+
+From the root of the repository:
+
+```shell
+sphinx-build -b html docs/source docs/build/html
+```
+
+You can now visualise the documentation webiste by opening `docs/build/html/index.html` with your web browser.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,27 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'NTDMC Trachoma model'
+copyright = '2024, Neglected Tropical Diseases Modelling Consortium'
+author = 'Neglected Tropical Diseases Modelling Consortium'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,184 @@
+.. NTDMC Trachoma model documentation master file, created by
+   sphinx-quickstart on Sun Sep  8 14:31:04 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to NTDMC Trachoma model's documentation!
+================================================
+
+On this page:
+
+.. contents::
+   :backlinks: none
+
+.. _installation:
+
+Installation
+~~~~~~~~~~~~
+
+We recommend that you install the model within a dedicated Python
+virtual environment. See `venv — Creation of virtual environments
+<https://docs.python.org/3/library/venv.html>`_ for more information
+about working with virtual environments.
+
+The model can be installed with the standard `pip` package management
+utility, specifying the URL of the project's GitHub repository
+followed by the string ``@v<x.y.z>`` where ``<x.y.z>`` is the version
+number.  The latest release's version number can be found `here <https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma/tags>`_.
+
+.. code:: shell
+
+   pip install git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma.git@v1.0.1
+
+Running the model
+~~~~~~~~~~~~~~~~~
+
+Currently, the model is expected to be used as a library through the
+unique entry point function `run_single_simulation`.  The calling code
+is expected to build the objects required to be passed as parameter of
+this model entry point function.
+
+.. code:: python
+
+   from ntd_trachoma import run_single_simulation
+
+   vals, results = run_single_simulation(
+       params, vals, timesim, burnin, demog, beta, MDA_times, MDAData,
+       vacc_times, VaccData, outputTimes, doSurvey, doIHMEOutput,
+       numpy_state,
+   )
+
+The arguments expected by the ``run_single_simulation`` function are
+described below.
+
+.. _expected-arguments:
+
+Expected arguments
+------------------
+
+NumPy arrays are one-dimensional arrays with one element per
+individual in the population.
+
+* ``params`` (``dict``) Dictionary made of the following keys:
+
+  * ``N`` (``int``)  The population size.
+  * ``av_I_duration`` (``float``) Average duration of the I state
+  * ``av_ID_duration`` (``float``) Average duration of the ID state
+  * ``av_D_duration`` (``float``) Average duration of the D state
+  * ``inf_red`` (``float``) Missing description
+  * ``dis_red`` (``float``) Missing description
+  * ``min_ID`` (``int``) Minimum duration for the ID state
+  * ``min_D`` (``int``) Minimum duration of the D state
+  * ``v_1`` (``float``) Missing description
+  * ``v_2`` (``float``) Missing description
+  * ``phi`` (``float``) Missing description
+  * ``epsilon`` (``float``) Missing description
+  * ``MDA_Eff`` (``float``) Efficacy of MDA treatment
+  * ``rho`` Correlation parameter for systematic non-compliance
+  * ``n_inf_sev`` Missing description
+
+* ``vals`` is a dictionary made of the following keys:
+
+  * ``IndI`` (``numpy.ndarray[int]``) Infected status for each
+    individual (`0` or `1`)
+  * ``IndD`` (``numpy.ndarray[int]``) Diseased status for each
+    individual (`0` or `1`)
+  * ``T_latent`` (``numpy.ndarray[int]``)  Latent period (weeks)
+  * ``T_ID`` (``numpy.ndarray[int]``)  ID period (weeks)
+  * ``T_D`` (``numpy.ndarray[int]``)  Diseased period (weeks)
+  * ``Ind_latent`` (``numpy.ndarray[float]``) Latent base period
+    (weeks)
+  * ``Ind_ID_period_base`` (``numpy.ndarray[float]``) ID base period
+    (weeks)
+  * ``bact_load`` ``numpy.ndarray[float]``  Bacterial load
+  * ``Age`` (``numpy.ndarray[int]``)  Age
+  * ``N_MDA`` (``int``)  Total number of MDA rounds.
+  * ``No_Inf`` ``numpy.ndarray[int]``  Total number of infections.
+  * ``True_Prev_Disease_children`` (``list[float]``) Diseased
+    prevalence among children aged 9 to 15 years old.  One list
+    element per simulated week.
+  * ``vaccinated`` (``numpy.ndarray[bool]``) Individuals vaccination
+    status
+  * ``treatProbability`` (``numpy.ndarray[float]``) MDA treatment
+    probability
+
+* ``MDAData`` (``list[list[float, int, int, float, int, int]]``) One
+  element per MDA round.  Each element is a list of 6 elements:
+
+  * The MDA round time (``float``), e.g. ``2022.53`` for a round
+    sometimes mid-june. Round times are expressed as iteration indices
+    within the ``MDA_times`` argument, see below.
+  * The population minimum age (``int``)
+  * The population maximum age (``int``)
+  * The MDA coverage value  (``float``)
+  * The MDA campaign index (``int``)
+  * The total number of MDA campaigns (``int``)
+
+* ``MDA_times`` (``list[int]``) One element per MDA round.  MDA times
+  as a number of iterations, inclusive of burnin time.
+
+* ``VaccData`` (``list[list[float, int, int, float, int, int]]``) One
+  element per vaccination round.  Each element is a list of 6
+  elements:
+
+  * The vaccination round time (``float``), e.g. ``2022.53`` for a
+    round sometimes mid-june. Round times are expressed as iteration
+    indices within the ``vaccination_times`` argument, see below.
+  * The population minimum age (``int``)
+  * The population maximum age (``int``)
+  * The vaccination coverage value  (``float``)
+  * The vaccination campaign index (``int``)
+  * The total number of vaccination campaigns (``int``)
+
+* ``vacc_times`` (``list[int]``) One element per vaccination round.
+  Vaccination times as a number of iterations, inclusive of burnin
+  time.
+
+* ``outputTimes`` (``list[int]``) Iteration indices at which to record
+  output.  See <simulation outputs>.
+
+* ``doSurvey`` (``bool``) Whether or not to carry surveys.
+
+* ``doIHMEOutput`` (``bool``) Whether or not to build IHME outputs.
+
+* ``numpy_state`` NumPy random generator state as returned by ``numpyp.random.get_state()``. See `numpy.random.get_state <https://numpy.org/doc/1.26/reference/random/generated/numpy.random.get_state.html>`_.
+
+.. _outputs:
+  
+Outputs
+-------
+
+The ``run_single_simulation`` function returns a 2-tuple ``(vals,
+results)``, which elements are described below.
+
+* ``vals`` (``dict``) The input dictionary ``vals`` with values
+  mutated to reflect the final state of the population.  See
+  :ref:`expected-arguments`.
+* ``results`` (``list[Result]``) Elements are instances of the
+  ``ntd-trachoma.Result`` class:
+
+  .. code:: python
+
+     @dataclass
+     class Result:
+         time: float
+         IndI: ndarray
+         IndD: ndarray
+         Age:ndarray
+         NoInf: ndarray
+         nMDA:Optional[ndarray] = None
+         nMDADoses: Optional[ndarray] = None
+         nVacc:Optional[ndarray] = None
+         nVaccDoses: Optional[ndarray] = None
+         nSurvey: Optional[int] = None
+         surveyPass: Optional[int] = None
+         elimination: Optional[int] = None
+         propMDA: Optional[ndarray] = None    
+         propVacc: Optional[ndarray] = None
+
+
+  The ``results`` list contains one element per output time,
+  defined by the ``outputTimes`` list argument to
+  ``run_single_simulation``.  See :ref:`expected-arguments`.
+
+


### PR DESCRIPTION
This adds sources for a documentation website to build with sphinx, together with a github actions workflow to automatically build and deploy the docs when sources are changed.

The content of the documentation is minimal, and currently only describe installation instructions and the entry point function `run_single_simulation`.

Rendered version [here](https://tlestang.github.io/ntd-model-trachoma/) (from my fork of this repo).

