### PR TITLE
allow exponential distribution for time in compartments

### DIFF
--- a/tests/test_updatedMDA.py
+++ b/tests/test_updatedMDA.py
@@ -8,7 +8,7 @@ from trachoma.trachoma_functions import *
 class TestMDAFunctionality(unittest.TestCase):
     # start by defining parameters for the run
     def setUp(self):
-        self.params = {'N': 2500,
+        self.params = {'N': 5000,
                        'av_I_duration': 2,
                        'av_ID_duration': 200/7,
                        'inf_red': 0.45,

--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -557,10 +557,12 @@ def Set_inits(params, demog, sim_params, MDAData, numpy_state, distToUse = "Pois
             # Individual's baseline diseased period (first infection)
         Ind_D_period_base=np.random.poisson(lam=params['av_D_duration'], size=params['N'])
     else:
-        Ind_ID_period_base=np.random.exponential(scale=params['av_ID_duration'], size=params['N'])
+        Ind_ID_period_base= np.round(np.random.exponential(scale=params['av_ID_duration'], size=params['N']))
 
             # Individual's baseline diseased period (first infection)
-        Ind_D_period_base=np.random.exponential(scale=params['av_D_duration'], size=params['N'])
+        Ind_D_period_base= np.round(np.random.exponential(scale=params['av_D_duration'], size=params['N']))
+        Ind_ID_period_base[Ind_ID_period_base == 0] = 1
+        Ind_D_period_base[Ind_D_period_base == 0] = 1
 
     if (len(MDAData) > 0):
         MDA_coverage = MDAData[0][3]
@@ -645,8 +647,12 @@ def Reset_vals(vals, reset_indivs, params, distToUse = "Poisson"):
         vals['Ind_ID_period_base'][reset_indivs] = np.random.poisson(lam=params['av_ID_duration'], size=numResetIndivs)
         vals['Ind_D_period_base'][reset_indivs] = np.random.poisson(lam=params['av_D_duration'], size=numResetIndivs)
     else:
-        vals['Ind_ID_period_base'][reset_indivs] = np.random.exponential(scale=params['av_ID_duration'], size=numResetIndivs)
-        vals['Ind_D_period_base'][reset_indivs] = np.random.exponential(scale=params['av_D_duration'], size=numResetIndivs)
+        ID_periods = np.round(np.random.exponential(scale=params['av_ID_duration'], size=numResetIndivs))
+        ID_periods[ID_periods == 0] = 1
+        vals['Ind_ID_period_base'][reset_indivs] = ID_periods
+        D_periods = np.round(np.random.exponential(scale=params['av_D_duration'], size=numResetIndivs))
+        D_periods[D_periods == 0] = 1
+        vals['Ind_D_period_base'][reset_indivs] = D_periods
     
     vals['bact_load'][reset_indivs] = 0
     vals['treatProbability'][reset_indivs] = drawTreatmentProbabilities(numResetIndivs, vals['MDA_coverage'], vals['systematic_non_compliance']),
@@ -676,8 +682,12 @@ def Import_individual(vals, import_indivs, params, demog, distToUse = "Poisson")
         vals['Ind_ID_period_base'][import_indivs] = np.random.poisson(lam=params['av_ID_duration'], size=numImportIndivs)
         vals['Ind_D_period_base'][import_indivs] = np.random.poisson(lam=params['av_D_duration'], size=numImportIndivs)
     else:
-        vals['Ind_ID_period_base'][import_indivs] = np.random.exponential(scale=params['av_ID_duration'], size=numImportIndivs)
-        vals['Ind_D_period_base'][import_indivs] = np.random.exponential(scale=params['av_D_duration'], size=numImportIndivs)
+        ID_periods = np.round(np.random.exponential(scale=params['av_ID_duration'], size=numImportIndivs))
+        ID_periods[ID_periods == 0] = 1
+        vals['Ind_ID_period_base'][import_indivs] = ID_periods
+        D_periods = np.round(np.random.exponential(scale=params['av_D_duration'], size=numImportIndivs))
+        D_periods[D_periods == 0] = 1
+        vals['Ind_D_period_base'][import_indivs] = D_periods
     vals['T_latent'][import_indivs] = 0
     vals['T_ID'][import_indivs] = ID_period_function(import_indivs, params, vals) * np.random.uniform()
     vals['T_D'][import_indivs] = 0


### PR DESCRIPTION
to match with ODE's the time spent in each compartment should be exponentially distributed rather than poisson distributed as originally set to be. this PR adds an option to choose the time in each compartment to have a mean chosen from an exponential distribution.